### PR TITLE
Ubuntu 24.04 PLUS root-less building

### DIFF
--- a/singularity-container/README
+++ b/singularity-container/README
@@ -4,7 +4,11 @@ github test runner.
 
 To use these scripts:
 
-1. Run ./build.sh to build baseimage.sif.
+1. You will require subuid and subgid enabled
+   (/etc/subuid and /etc/subgid - USERNAME:ID:COUNT e.g. myuser:10000:5000)
+   for root-less build.
+
+1. Run ./build.sh to build baseimage.sif. or sudo ./build.sh if you dont have sub*ids
 
    Note that sudo is used here, but nowhere else.
 

--- a/singularity-container/README
+++ b/singularity-container/README
@@ -8,11 +8,11 @@ To use these scripts:
    (/etc/subuid and /etc/subgid - USERNAME:ID:COUNT e.g. myuser:10000:5000)
    for root-less build.
 
-1. Run ./build.sh to build baseimage.sif. or sudo ./build.sh if you dont have sub*ids
+2. Run ./build.sh to build baseimage.sif. or sudo ./build.sh if you dont have sub*ids
 
    Note that sudo is used here, but nowhere else.
 
-2. Run ./config.sh to create $TMP/pysecdec-github-runner directory
+3. Run ./config.sh to create $TMP/pysecdec-github-runner directory
    with all the needed files set up, and register the runner on
    Github. Note that you'll need to go to Settings->Actions->Self-hosted
    runners->Add runner to get the registration token. Only Github project
@@ -21,13 +21,13 @@ To use these scripts:
    Note that ./config.sh can be re-run multiple times, and it will
    recreate and re-register everything anew.
 
-3. You can run ./clear.sh to remove $TMP/pysecdec-github-runner.
+4. You can run ./clear.sh to remove $TMP/pysecdec-github-runner.
 
-4. You can run ./run.sh to run Github Runner in the foreground.
+5. You can run ./run.sh to run Github Runner in the foreground.
 
-5. You can run ./shell.sh to log into the container (using Bash).
+6. You can run ./shell.sh to log into the container (using Bash).
 
-6. You can run ./daemon-start.sh to start ./run.sh in the background
+7. You can run ./daemon-start.sh to start ./run.sh in the background
    (as a daemon).
 
    If you did, then ./daemon-status.sh will print the status of this

--- a/singularity-container/baseimage.def
+++ b/singularity-container/baseimage.def
@@ -2,7 +2,6 @@ Bootstrap: docker
 From: ubuntu:24.04
 
 %post
-    chmod 777 /tmp
     cat /etc/apt/sources.list | sed -e 's/main$/universe/' > /etc/apt/sources.list.d/universe.list
     env DEBIAN_FRONTEND=noninteractive apt-get -y update
     env DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential graphviz normaliz nauty libgsl-dev daemon git autoconf gcc python3 python3-pip

--- a/singularity-container/baseimage.def
+++ b/singularity-container/baseimage.def
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: ubuntu:20.04
+From: ubuntu:24.04
 
 %post
     chmod 777 /tmp

--- a/singularity-container/baseimage.def
+++ b/singularity-container/baseimage.def
@@ -5,5 +5,5 @@ From: ubuntu:24.04
     chmod 777 /tmp
     cat /etc/apt/sources.list | sed -e 's/main$/universe/' > /etc/apt/sources.list.d/universe.list
     env DEBIAN_FRONTEND=noninteractive apt-get -y update
-    env DEBIAN_FRONTEND=noninteractive apt-get -y install python3 python3-pip graphviz normaliz nauty libgsl-dev daemon git autoconf
+    env DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential graphviz normaliz nauty libgsl-dev daemon git autoconf gcc python3 python3-pip
     env DEBIAN_FRONTEND=noninteractive apt-get -y clean

--- a/singularity-container/build.sh
+++ b/singularity-container/build.sh
@@ -2,7 +2,8 @@
 
 srcdir=$(dirname "$0")
 img=baseimage.sif
-tmpimg=${TMP:-/tmp}/$img
+tmpdir=$(mktemp -d)
+tmpimg=${tmpdir}/$img
 
-sudo singularity build "$tmpimg" "$srcdir/${img%.sif}.def" || exit 1
+singularity build "$tmpimg" "$srcdir/${img%.sif}.def" || exit 1
 mv "$tmpimg" "$srcdir/$img"


### PR DESCRIPTION
The requirement for root to build is purely for fake-root (and the weird chmod 777 /tmp).

A modern Linux system should allow for sub*ids eg subuid and subgid; if they don't then you need to edit `/etc/subuid` and `/etc/subgid`.

This will also allow you to run `sudo ./build.sh` to also not require the sub*ids